### PR TITLE
Skip logging fatal in case of Unimplmented messages

### DIFF
--- a/Sources/action_server/action_server.go
+++ b/Sources/action_server/action_server.go
@@ -35,7 +35,7 @@ func (a *ServiceImpl) ArmDisarm(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ArmDisarm messages, err: %v", err)
@@ -68,7 +68,7 @@ func (a *ServiceImpl) FlightModeChange(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive FlightModeChange messages, err: %v", err)
@@ -101,7 +101,7 @@ func (a *ServiceImpl) Takeoff(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Takeoff messages, err: %v", err)
@@ -134,7 +134,7 @@ func (a *ServiceImpl) Land(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Land messages, err: %v", err)
@@ -167,7 +167,7 @@ func (a *ServiceImpl) Reboot(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Reboot messages, err: %v", err)
@@ -200,7 +200,7 @@ func (a *ServiceImpl) Shutdown(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Shutdown messages, err: %v", err)
@@ -233,7 +233,7 @@ func (a *ServiceImpl) Terminate(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Terminate messages, err: %v", err)

--- a/Sources/arm_authorizer_server/arm_authorizer_server.go
+++ b/Sources/arm_authorizer_server/arm_authorizer_server.go
@@ -35,7 +35,7 @@ func (a *ServiceImpl) ArmAuthorization(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ArmAuthorization messages, err: %v", err)

--- a/Sources/calibration/calibration.go
+++ b/Sources/calibration/calibration.go
@@ -35,7 +35,7 @@ func (a *ServiceImpl) CalibrateGyro(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive CalibrateGyro messages, err: %v", err)
@@ -68,7 +68,7 @@ func (a *ServiceImpl) CalibrateAccelerometer(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive CalibrateAccelerometer messages, err: %v", err)
@@ -101,7 +101,7 @@ func (a *ServiceImpl) CalibrateMagnetometer(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive CalibrateMagnetometer messages, err: %v", err)
@@ -134,7 +134,7 @@ func (a *ServiceImpl) CalibrateLevelHorizon(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive CalibrateLevelHorizon messages, err: %v", err)
@@ -167,7 +167,7 @@ func (a *ServiceImpl) CalibrateGimbalAccelerometer(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive CalibrateGimbalAccelerometer messages, err: %v", err)

--- a/Sources/camera/camera.go
+++ b/Sources/camera/camera.go
@@ -214,7 +214,7 @@ func (a *ServiceImpl) CameraList(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive CameraList messages, err: %v", err)
@@ -247,7 +247,7 @@ func (a *ServiceImpl) Mode(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Mode messages, err: %v", err)
@@ -298,7 +298,7 @@ func (a *ServiceImpl) VideoStreamInfo(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive VideoStreamInfo messages, err: %v", err)
@@ -349,7 +349,7 @@ func (a *ServiceImpl) CaptureInfo(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive CaptureInfo messages, err: %v", err)
@@ -382,7 +382,7 @@ func (a *ServiceImpl) Storage(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Storage messages, err: %v", err)
@@ -433,7 +433,7 @@ func (a *ServiceImpl) CurrentSettings(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive CurrentSettings messages, err: %v", err)
@@ -484,7 +484,7 @@ func (a *ServiceImpl) PossibleSettingOptions(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive PossibleSettingOptions messages, err: %v", err)

--- a/Sources/camera_server/camera_server.go
+++ b/Sources/camera_server/camera_server.go
@@ -89,7 +89,7 @@ func (a *ServiceImpl) TakePhoto(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive TakePhoto messages, err: %v", err)
@@ -143,7 +143,7 @@ func (a *ServiceImpl) StartVideo(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive StartVideo messages, err: %v", err)
@@ -194,7 +194,7 @@ func (a *ServiceImpl) StopVideo(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive StopVideo messages, err: %v", err)
@@ -245,7 +245,7 @@ func (a *ServiceImpl) StartVideoStreaming(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive StartVideoStreaming messages, err: %v", err)
@@ -296,7 +296,7 @@ func (a *ServiceImpl) StopVideoStreaming(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive StopVideoStreaming messages, err: %v", err)
@@ -347,7 +347,7 @@ func (a *ServiceImpl) SetMode(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive SetMode messages, err: %v", err)
@@ -398,7 +398,7 @@ func (a *ServiceImpl) StorageInformation(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive StorageInformation messages, err: %v", err)
@@ -452,7 +452,7 @@ func (a *ServiceImpl) CaptureStatus(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive CaptureStatus messages, err: %v", err)
@@ -506,7 +506,7 @@ func (a *ServiceImpl) FormatStorage(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive FormatStorage messages, err: %v", err)
@@ -557,7 +557,7 @@ func (a *ServiceImpl) ResetSettings(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ResetSettings messages, err: %v", err)
@@ -608,7 +608,7 @@ func (a *ServiceImpl) ZoomInStart(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ZoomInStart messages, err: %v", err)
@@ -659,7 +659,7 @@ func (a *ServiceImpl) ZoomOutStart(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ZoomOutStart messages, err: %v", err)
@@ -710,7 +710,7 @@ func (a *ServiceImpl) ZoomStop(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ZoomStop messages, err: %v", err)
@@ -761,7 +761,7 @@ func (a *ServiceImpl) ZoomRange(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ZoomRange messages, err: %v", err)
@@ -845,7 +845,7 @@ func (a *ServiceImpl) TrackingPointCommand(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive TrackingPointCommand messages, err: %v", err)
@@ -878,7 +878,7 @@ func (a *ServiceImpl) TrackingRectangleCommand(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive TrackingRectangleCommand messages, err: %v", err)
@@ -911,7 +911,7 @@ func (a *ServiceImpl) TrackingOffCommand(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive TrackingOffCommand messages, err: %v", err)

--- a/Sources/component_metadata/component_metadata.go
+++ b/Sources/component_metadata/component_metadata.go
@@ -72,7 +72,7 @@ func (a *ServiceImpl) MetadataAvailable(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive MetadataAvailable messages, err: %v", err)

--- a/Sources/core/core.go
+++ b/Sources/core/core.go
@@ -35,7 +35,7 @@ func (a *ServiceImpl) ConnectionState(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ConnectionState messages, err: %v", err)

--- a/Sources/ftp/ftp.go
+++ b/Sources/ftp/ftp.go
@@ -42,7 +42,7 @@ func (a *ServiceImpl) Download(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Download messages, err: %v", err)
@@ -80,7 +80,7 @@ func (a *ServiceImpl) Upload(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Upload messages, err: %v", err)

--- a/Sources/gimbal/gimbal.go
+++ b/Sources/gimbal/gimbal.go
@@ -186,7 +186,7 @@ func (a *ServiceImpl) GimbalList(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive GimbalList messages, err: %v", err)
@@ -223,7 +223,7 @@ func (a *ServiceImpl) ControlStatus(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ControlStatus messages, err: %v", err)
@@ -276,7 +276,7 @@ func (a *ServiceImpl) Attitude(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Attitude messages, err: %v", err)

--- a/Sources/info/info.go
+++ b/Sources/info/info.go
@@ -110,7 +110,7 @@ func (a *ServiceImpl) FlightInformation(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive FlightInformation messages, err: %v", err)

--- a/Sources/log_files/log_files.go
+++ b/Sources/log_files/log_files.go
@@ -57,7 +57,7 @@ func (a *ServiceImpl) DownloadLogFile(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive DownloadLogFile messages, err: %v", err)

--- a/Sources/log_streaming/log_streaming.go
+++ b/Sources/log_streaming/log_streaming.go
@@ -65,7 +65,7 @@ func (a *ServiceImpl) LogStreamingRaw(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive LogStreamingRaw messages, err: %v", err)

--- a/Sources/mission/mission.go
+++ b/Sources/mission/mission.go
@@ -62,7 +62,7 @@ func (a *ServiceImpl) UploadMissionWithProgress(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive UploadMissionWithProgress messages, err: %v", err)
@@ -131,7 +131,7 @@ func (a *ServiceImpl) DownloadMissionWithProgress(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive DownloadMissionWithProgress messages, err: %v", err)
@@ -270,7 +270,7 @@ func (a *ServiceImpl) MissionProgress(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive MissionProgress messages, err: %v", err)

--- a/Sources/mission_raw/mission_raw.go
+++ b/Sources/mission_raw/mission_raw.go
@@ -240,7 +240,7 @@ func (a *ServiceImpl) MissionProgress(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive MissionProgress messages, err: %v", err)
@@ -278,7 +278,7 @@ func (a *ServiceImpl) MissionChanged(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive MissionChanged messages, err: %v", err)

--- a/Sources/mission_raw_server/mission_raw_server.go
+++ b/Sources/mission_raw_server/mission_raw_server.go
@@ -35,7 +35,7 @@ func (a *ServiceImpl) IncomingMission(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive IncomingMission messages, err: %v", err)
@@ -68,7 +68,7 @@ func (a *ServiceImpl) CurrentItemChanged(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive CurrentItemChanged messages, err: %v", err)
@@ -116,7 +116,7 @@ func (a *ServiceImpl) ClearAll(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ClearAll messages, err: %v", err)

--- a/Sources/param_server/param_server.go
+++ b/Sources/param_server/param_server.go
@@ -198,7 +198,7 @@ func (a *ServiceImpl) ChangedParamInt(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ChangedParamInt messages, err: %v", err)
@@ -231,7 +231,7 @@ func (a *ServiceImpl) ChangedParamFloat(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ChangedParamFloat messages, err: %v", err)
@@ -264,7 +264,7 @@ func (a *ServiceImpl) ChangedParamCustom(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ChangedParamCustom messages, err: %v", err)

--- a/Sources/shell/shell.go
+++ b/Sources/shell/shell.go
@@ -55,7 +55,7 @@ func (a *ServiceImpl) Receive(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Receive messages, err: %v", err)

--- a/Sources/telemetry/telemetry.go
+++ b/Sources/telemetry/telemetry.go
@@ -35,7 +35,7 @@ func (a *ServiceImpl) Position(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Position messages, err: %v", err)
@@ -68,7 +68,7 @@ func (a *ServiceImpl) Home(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Home messages, err: %v", err)
@@ -101,7 +101,7 @@ func (a *ServiceImpl) InAir(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive InAir messages, err: %v", err)
@@ -134,7 +134,7 @@ func (a *ServiceImpl) LandedState(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive LandedState messages, err: %v", err)
@@ -167,7 +167,7 @@ func (a *ServiceImpl) Armed(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Armed messages, err: %v", err)
@@ -200,7 +200,7 @@ func (a *ServiceImpl) VtolState(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive VtolState messages, err: %v", err)
@@ -233,7 +233,7 @@ func (a *ServiceImpl) AttitudeQuaternion(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive AttitudeQuaternion messages, err: %v", err)
@@ -266,7 +266,7 @@ func (a *ServiceImpl) AttitudeEuler(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive AttitudeEuler messages, err: %v", err)
@@ -299,7 +299,7 @@ func (a *ServiceImpl) AttitudeAngularVelocityBody(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive AttitudeAngularVelocityBody messages, err: %v", err)
@@ -332,7 +332,7 @@ func (a *ServiceImpl) VelocityNed(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive VelocityNed messages, err: %v", err)
@@ -365,7 +365,7 @@ func (a *ServiceImpl) GpsInfo(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive GpsInfo messages, err: %v", err)
@@ -398,7 +398,7 @@ func (a *ServiceImpl) RawGps(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive RawGps messages, err: %v", err)
@@ -431,7 +431,7 @@ func (a *ServiceImpl) Battery(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Battery messages, err: %v", err)
@@ -464,7 +464,7 @@ func (a *ServiceImpl) FlightMode(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive FlightMode messages, err: %v", err)
@@ -497,7 +497,7 @@ func (a *ServiceImpl) Health(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Health messages, err: %v", err)
@@ -530,7 +530,7 @@ func (a *ServiceImpl) RcStatus(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive RcStatus messages, err: %v", err)
@@ -563,7 +563,7 @@ func (a *ServiceImpl) StatusText(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive StatusText messages, err: %v", err)
@@ -596,7 +596,7 @@ func (a *ServiceImpl) ActuatorControlTarget(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ActuatorControlTarget messages, err: %v", err)
@@ -629,7 +629,7 @@ func (a *ServiceImpl) ActuatorOutputStatus(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ActuatorOutputStatus messages, err: %v", err)
@@ -662,7 +662,7 @@ func (a *ServiceImpl) Odometry(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Odometry messages, err: %v", err)
@@ -695,7 +695,7 @@ func (a *ServiceImpl) PositionVelocityNed(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive PositionVelocityNed messages, err: %v", err)
@@ -728,7 +728,7 @@ func (a *ServiceImpl) GroundTruth(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive GroundTruth messages, err: %v", err)
@@ -761,7 +761,7 @@ func (a *ServiceImpl) FixedwingMetrics(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive FixedwingMetrics messages, err: %v", err)
@@ -794,7 +794,7 @@ func (a *ServiceImpl) Imu(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Imu messages, err: %v", err)
@@ -827,7 +827,7 @@ func (a *ServiceImpl) ScaledImu(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ScaledImu messages, err: %v", err)
@@ -860,7 +860,7 @@ func (a *ServiceImpl) RawImu(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive RawImu messages, err: %v", err)
@@ -893,7 +893,7 @@ func (a *ServiceImpl) HealthAllOk(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive HealthAllOk messages, err: %v", err)
@@ -926,7 +926,7 @@ func (a *ServiceImpl) UnixEpochTime(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive UnixEpochTime messages, err: %v", err)
@@ -959,7 +959,7 @@ func (a *ServiceImpl) DistanceSensor(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive DistanceSensor messages, err: %v", err)
@@ -992,7 +992,7 @@ func (a *ServiceImpl) ScaledPressure(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive ScaledPressure messages, err: %v", err)
@@ -1025,7 +1025,7 @@ func (a *ServiceImpl) Heading(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Heading messages, err: %v", err)
@@ -1058,7 +1058,7 @@ func (a *ServiceImpl) Altitude(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Altitude messages, err: %v", err)
@@ -1091,7 +1091,7 @@ func (a *ServiceImpl) Wind(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Wind messages, err: %v", err)

--- a/Sources/transponder/transponder.go
+++ b/Sources/transponder/transponder.go
@@ -35,7 +35,7 @@ func (a *ServiceImpl) Transponder(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Transponder messages, err: %v", err)

--- a/Sources/winch/winch.go
+++ b/Sources/winch/winch.go
@@ -35,7 +35,7 @@ func (a *ServiceImpl) Status(
 				return
 			}
 			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+				if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
 					return
 				}
 				log.Fatalf("Unable to receive Status messages, err: %v", err)

--- a/templates/stream.j2
+++ b/templates/stream.j2
@@ -20,7 +20,7 @@ func (a *ServiceImpl) {{ name.upper_camel_case }}(
                 return
             }
             if err != nil {
-                if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
+                if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.Unimplemented) {
                     return
                 }
                 log.Fatalf("Unable to receive {{ name.upper_camel_case }} messages, err: %v", err)


### PR DESCRIPTION
For unimplemented messages types, logging fatal was not intended.